### PR TITLE
Add logic to includes operator to handle false

### DIFF
--- a/lib/__tests__/rules.test.js
+++ b/lib/__tests__/rules.test.js
@@ -303,10 +303,14 @@ describe('JSON-Rules', () => {
             expect(evaluate(['includes', ['foo', 'bar', 'baz'], 'biz'])).toEqual(false);
         });
 
+        it('should return false if the value to be searched is false', () => {
+            expect(evaluate(['includes', false, 'foo'])).toEqual(false);
+        });
+
         it('should throw if the value to be searched is not an array', () => {
             expect(() => {
                 evaluate(['includes', 'bar', 'bar']);
-            }).toThrow(/^"includes" operator expected an array but recieved: bar$/);
+            }).toThrow(/^"includes" operator expected an array but received: bar$/);
         });
     });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,10 @@ function createJSONRules() {
                 return hasValue ? ['break;', true] : breakFalse;
             }
 
-            throw Error(`"includes" operator expected an array but recieved: ${arr}`);
+            if (arr === false) {
+                return breakFalse;
+            }
+            throw Error(`"includes" operator expected an array but received: ${arr}`);
         },
         and: (rule, data) => {
             for (let i = 1, len = rule.length; i < len; i += 1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "json-rules",
-    "version": "0.5.0",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "json-rules",
-    "version": "0.3.0",
+    "version": "0.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "json-rules",
-    "version": "0.5.0",
+    "version": "1.0.0",
     "description": "Evaluate logic rules in JSON",
     "homepage": "",
     "author": "Stephen S <webstacker@outlook.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "json-rules",
-    "version": "0.3.0",
+    "version": "0.5.0",
     "description": "Evaluate logic rules in JSON",
     "homepage": "",
     "author": "Stephen S <webstacker@outlook.com>",


### PR DESCRIPTION
Includes operator now handles false values.

Now that undefined data references are returned as false, it is necessary for the includes operator to handle false, and not simply throw if the value being searched is not an array.